### PR TITLE
chore: release v1.0.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,32 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.0.1](https://github.com/elmarx/miffy/compare/v1.0.0...v1.0.1) - 2025-05-19
+
+### Fixed
+
+- fix value of "upstream" header in demo
+- fix send mutated request (with shadow-test-role-header) to upstream
+- *(deps)* update rust crate tower-http to v0.6.4
+- *(deps)* update rust crate tokio to v1.45.0
+- *(deps)* update rust crate tokio to v1.44.2 [security]
+- *(deps)* update rust crate anyhow to v1.0.98
+- *(deps)* update rust crate hyper-util to v0.1.11
+- *(deps)* update rust crate tracing-opentelemetry to 0.30.0
+
+### Other
+
+- *(deps)* update renovatebot/github-action action to v42.0.3
+- *(deps)* update rust docker tag to v1.87.0
+- *(deps)* update renovatebot/github-action action to v42
+- *(deps)* update rust crate axum to v0.8.4
+- update zstd-sys
+- *(deps)* update rust docker tag to v1.86.0
+- *(deps)* update renovatebot/github-action action to v41.0.22
+- *(deps)* update renovatebot/github-action action to v41.0.21
+- *(deps)* update renovatebot/github-action action to v41.0.20
+- *(deps)* update renovatebot/github-action action to v41.0.19
+
 ## [1.0.0](https://github.com/elmarx/miffy/compare/v0.1.0...v1.0.0) - 2025-04-01
 
 ### Other

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -872,7 +872,7 @@ checksum = "78ca9ab1a0babb1e7d5695e3530886289c18cf2f87ec19a575a0abdce112e3a3"
 
 [[package]]
 name = "miffy"
-version = "1.0.0"
+version = "1.0.1"
 dependencies = [
  "anyhow",
  "axum",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "miffy"
-version = "1.0.0"
+version = "1.0.1"
 edition = "2024"
 authors = ["Elmar Athmer"]
 license = "MIT OR Apache-2.0"


### PR DESCRIPTION



## 🤖 New release

* `miffy`: 1.0.0 -> 1.0.1

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [1.0.1](https://github.com/elmarx/miffy/compare/v1.0.0...v1.0.1) - 2025-05-19

### Fixed

- fix value of "upstream" header in demo
- fix send mutated request (with shadow-test-role-header) to upstream
- *(deps)* update rust crate tower-http to v0.6.4
- *(deps)* update rust crate tokio to v1.45.0
- *(deps)* update rust crate tokio to v1.44.2 [security]
- *(deps)* update rust crate anyhow to v1.0.98
- *(deps)* update rust crate hyper-util to v0.1.11
- *(deps)* update rust crate tracing-opentelemetry to 0.30.0

### Other

- *(deps)* update renovatebot/github-action action to v42.0.3
- *(deps)* update rust docker tag to v1.87.0
- *(deps)* update renovatebot/github-action action to v42
- *(deps)* update rust crate axum to v0.8.4
- update zstd-sys
- *(deps)* update rust docker tag to v1.86.0
- *(deps)* update renovatebot/github-action action to v41.0.22
- *(deps)* update renovatebot/github-action action to v41.0.21
- *(deps)* update renovatebot/github-action action to v41.0.20
- *(deps)* update renovatebot/github-action action to v41.0.19
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).