### PR TITLE
chore: release v1.0.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.0.2](https://github.com/elmarx/miffy/compare/v1.0.1...v1.0.2) - 2025-11-18
+
+### Other
+
+- *(deps)* update actions/checkout action to v4.3.1
+- *(deps)* update actions/checkout action to v4.3.0
+- *(deps)* update rust docker tag to v1.88.0
+- update dependencies
+- *(deps)* update renovatebot/github-action action to v42.0.6
+- *(deps)* update renovatebot/github-action action to v42.0.5
+- *(deps)* update apache/kafka docker tag to v3.9.1
+- *(deps)* update renovatebot/github-action action to v42.0.4
+
 ## [1.0.1](https://github.com/elmarx/miffy/compare/v1.0.0...v1.0.1) - 2025-05-19
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -880,7 +880,7 @@ checksum = "32a282da65faaf38286cf3be983213fcf1d2e2a58700e808f83f4ea9a4804bc0"
 
 [[package]]
 name = "miffy"
-version = "1.0.1"
+version = "1.0.2"
 dependencies = [
  "anyhow",
  "axum",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "miffy"
-version = "1.0.1"
+version = "1.0.2"
 edition = "2024"
 authors = ["Elmar Athmer"]
 license = "MIT OR Apache-2.0"


### PR DESCRIPTION



## 🤖 New release

* `miffy`: 1.0.1 -> 1.0.2

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [1.0.2](https://github.com/elmarx/miffy/compare/v1.0.1...v1.0.2) - 2025-11-18

### Other

- *(deps)* update actions/checkout action to v4.3.1
- *(deps)* update actions/checkout action to v4.3.0
- *(deps)* update rust docker tag to v1.88.0
- update dependencies
- *(deps)* update renovatebot/github-action action to v42.0.6
- *(deps)* update renovatebot/github-action action to v42.0.5
- *(deps)* update apache/kafka docker tag to v3.9.1
- *(deps)* update renovatebot/github-action action to v42.0.4
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).